### PR TITLE
we used HashRouter instead of browserRouter to enable pages routing

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter } from "react-router-dom";
+import { HashRouter } from "react-router-dom";
 import ReactDOM from "react-dom";
 import "antd/dist/antd.css";
 import "./App.css"; // Import your custom CSS file
@@ -14,9 +14,9 @@ const App: React.FC = () => {
 
   return (
     <div>
-      <BrowserRouter  basename='/epos-open-source'>
+      <HashRouter   basename='/epos-open-source'>
           <Router />
-      </BrowserRouter>
+      </HashRouter >
 
       {/* <button
         onClick={() => setIsFakeDark((prev) => !prev)}


### PR DESCRIPTION
we used HashRouter instead of browserRouter to enable pages routing , because if you copy full path for example 
https://epos-eu.github.io/epos-open-source/install
The page will break and it will show 404